### PR TITLE
fix path formatting of root (/) subdirectories

### DIFF
--- a/xfiles.c
+++ b/xfiles.c
@@ -163,6 +163,8 @@ fullpath(char *dir, char *file)
 {
 	char buf[PATH_MAX];
 
+	if (strcmp(dir, "/") == 0)
+		dir = "";
 	(void)snprintf(buf, sizeof(buf), "%s/%s", dir, file);
 	return estrdup(buf);
 }


### PR DESCRIPTION
PARENT/CHILD is not a valid format for root subdirectories
since you will be getting //usr, //dev, //sbin, etc...