### PR TITLE
fix detection of HOME & HOME subdirectories

### DIFF
--- a/xfiles.c
+++ b/xfiles.c
@@ -533,7 +533,8 @@ diropen(struct FM *fm, struct Cwd *cwd, const char *path)
 			}
 		}
 	}
-	if (strstr(cwd->path, fm->home) == cwd->path)
+	if (strcmp(cwd->path, fm->home) == 0 ||
+			(strstr(cwd->path, fm->home) == cwd->path && cwd->path[fm->homelen] == '/'))
 		snprintf(buf, PATH_MAX, "~%s", cwd->path + fm->homelen);
 	else
 		snprintf(buf, PATH_MAX, "%s", cwd->path);


### PR DESCRIPTION
suppose your HOME is set to /home/user, then if you enter
to the /home/user123456/test_dir directory the `cwd->here` variable
will be wrongly set to ~123456/test_dir, since it only checks that
the the value of `path` starts with the value of HOME