### PR TITLE
fix gcc overflow warning

### DIFF
--- a/widget.c
+++ b/widget.c
@@ -2876,7 +2876,7 @@ setthumbnail(Widget wid, char *path, int item)
 	size_t size, i;
 	int w, h;
 	char buf[DATA_DEPTH];
-	char *data;
+	unsigned char *data;
 
 	if (item < 0 || item >= wid->nitems || wid->thumbs == NULL)
 		return;
@@ -2932,7 +2932,7 @@ setthumbnail(Widget wid, char *path, int item)
 		wid->visual,
 		wid->depth,
 		ZPixmap,
-		0, data,
+		0, (char *)data,
 		w, h,
 		DATA_DEPTH * BYTE,
 		0


### PR DESCRIPTION
<details>
  <summary>GCC Error</summary>
  
  ```
widget.c:2916:44: warning: overflow in conversion from ‘int’ to ‘char’ changes value from ‘255’ to ‘-1’ [-Woverflow]
 2916 |                 data[i * DATA_DEPTH + 3] = 0xFF;     /* A */
       |                                            ^~~~
  ```
</details>