### PR TITLE
config: seperate jpeg, new entries

### DIFF
--- a/config.c
+++ b/config.c
@@ -48,11 +48,11 @@
  * - Element [n-1] is the obligatory NULL.
  */
 static char *file_app[]        = { "fx", NULL };
-static char *file_archive[]    = { "f", "*.zip", "*.tar", "*.gz", "*.bz2", "*.rar", NULL };
+static char *file_archive[]    = { "f", "*.zip", "*.tar.*", "*.gz", "*.bz2", "*.rar", NULL };
 static char *file_audio[]      = { "f", "*.mp[23]", "*.m4a", "*.m3u", "*.ogg", "*.opus", "*.flac", NULL };
-static char *file_code[]       = { "f", "*.c", "*.h", "*.s", NULL };
+static char *file_code[]       = { "f", "*.c", "*.cpp", "*.h", "*.s", "*.sh", NULL };
 static char *file_core[]       = { "f", "*.core", NULL };
-static char *file_config[]     = { "f", "*.conf", "*.config", "*.yaml", "*.toml", "*.xml", "*.ini", NULL };
+static char *file_config[]     = { "f", "*.conf", "*.yaml", "*.toml", "*.xml", "*.ini", NULL };
 #ifdef USE_NETPBM
 static char *file_xbm[]        = { "f", "*.xbm", NULL };
 static char *file__xpm[]       = { "f", "*.xpm", NULL };
@@ -61,15 +61,15 @@ static char *file_png[]        = { "f", "*.png", NULL };
 static char *file_bmp[]        = { "f", "*.bmp", NULL };
 static char *file_gif[]        = { "f", "*.gif", NULL };
 static char *file_tiff[]       = { "f", "*.tiff", NULL };
-static char *file_jpeg[]       = { "f", "*.jpeg", "*.jpg", NULL };
 #endif
-static char *file_image[]      = { "f", "*.x[pb]m", "*.png", "*.jpg", "*.jpeg", "*.p[bgp]m", "*.gif", NULL };
+static char *file_image[]      = { "f", "*.x[pb]m", "*.png", "*.p[bgp]m", "*.gif", NULL };
+static char *file_jpeg[]       = { "f", "*.jpeg", "*.jpe", "*.jpg", "*.jfi", "*.jif", "*.jfif", NULL };
 static char *file_svg[]        = { "f", "*.svg", NULL };
-static char *file_manual[]     = { "f", "*.[1-9]", "*.3p", "README", "README.md", "COPYING", "LICENSE", "COPYRIGHT", NULL };
+static char *file_manual[]     = { "f", "*.[1-9]", "*.3p", "README*", "COPYING", "LICENSE", "COPYRIGHT", NULL };
 static char *file_makefile[]   = { "f", "[Mm]akefile", "configure", NULL };
 static char *file_pdf[]        = { "f", "*.pdf", NULL };
-static char *file_object[]     = { "f", "*.o", "*.so", "*.a", "lib*", NULL };
-static char *file_text[]       = { "f", "*.epub", "*.txt", "*.ps", "*.eps", "*.djvu", NULL };
+static char *file_object[]     = { "f", "*.o", "*.so", "*.a", "lib*", "*.hex", "*.rom", NULL };
+static char *file_text[]       = { "f", "*.epub", "*.txt", "*.ps", "*.eps", "*.djvu", "*.csv", "*.md", NULL };
 static char *file_video[]      = { "f", "*.mp4", "*.webm", "*.mkv", "*.mov", "*.ogv", NULL };
 static char *folder_bin[]      = { "d", "~/usr", "~/bin", NULL };
 static char *folder_code[]     = { "d", "~/prj", "~/proj", "~/code", "~/[Pp]rojects", NULL };
@@ -102,6 +102,7 @@ char **icons[][2] = {
 	{ file_config,     file_config_xpm,     },
 	{ file_makefile,   file_gear_xpm,       },
 	{ file_image,      file_image_xpm,      },
+	{ file_jpeg,       file_image_xpm,      },
 	{ file_svg,        file_image_xpm,      },
 	{ file_manual,     file_info_xpm,       },
 	{ file_object,     file_object_xpm,     },
@@ -210,6 +211,7 @@ char **thumbs[][2] = {
 	{ file_jpeg,       jpegtopnm, },
 #else
 	{ file_image,      imagemagick, },
+	{ file_jpeg,       imagemagick, },
 #endif
 	{ file_svg,        rsvgconvert, },
 	{ file_pdf,        pdftoppm,    },


### PR DESCRIPTION
* file_jpeg for the 900 formats of jpeg
* there are many tar-formatted archives that will not be previewed by xfiles, such as .tar.xz
* have some love for shell scripts and c++.
* no configuration format is called 'foo.config'
* not all READMEs are created equally
* added firmware to file_object
* have some love for csv and markdown