### PR TITLE
Fix one minor typo in manual page

### DIFF
--- a/xfiles.1
+++ b/xfiles.1
@@ -243,7 +243,7 @@ No action other than scrolling can be performed while in this mode.
 To exit this mode, press the second mouse button
 (or release it, if the pointer had not been released nor moved outside the scroller).
 .It Dragging Mode
-This mode is entered after dragging ithe pointer on a file with the first button in normal mode.
+This mode is entered after dragging the pointer on a file with the first button in normal mode.
 In this mode, the file icon follows the mouse cursor, indicating that the file can be dropped on another window.
 .It Waiting Mode
 This mode is entered after


### PR DESCRIPTION
Changes one 'ithe' to 'the' in `xfiles.1` manual page.