### PR TITLE
added the sortBy resource and _CONTROL_SORTBY property

### DIFF
--- a/examples/xfilesctl
+++ b/examples/xfilesctl
@@ -364,6 +364,11 @@ changedir() {
 	xprop -id "$WINDOWID" -format "_CONTROL_GOTO" 8u -set "_CONTROL_GOTO" "$1"
 }
 
+# change the sort order of XFiles window
+sortby() {
+	xprop -id "$WINDOWID" -format "_CONTROL_SORTBY" 8u -set "_CONTROL_SORTBY" "$1"
+}
+
 # prompt for file to open or directory to go to
 urlbar() {
 	printf '%s\n' * | prompt | {
@@ -418,6 +423,10 @@ open
 	xfiles
 	term
 	random
+sort by
+	name
+	time
+	size
 $(case "$PWD" in ("$TRASH/files") printf 'empty trash' ;; (*) printf 'trash can' ;; esac)
 EOF
 	} | menu | {
@@ -458,6 +467,9 @@ EOF
 			;;
 		("xfiles")
 			newwin
+			;;
+		("name"|"time"|"size")
+			sortby "$option"
 			;;
 		esac
 	}

--- a/widget.h
+++ b/widget.h
@@ -6,6 +6,8 @@ typedef struct Scroll {
 
 typedef struct Item {
 	unsigned char mode;     /* entry mode */
+	struct timespec mtime;	/* modification time */
+	size_t size;		/* file size in bytes */
 	char *name;             /* item display name */
 	char *fullname;         /* item full name */
 	char *status;           /* item statusbar info */
@@ -21,6 +23,7 @@ typedef enum {
 	WIDGET_PREV,
 	WIDGET_NEXT,
 	WIDGET_GOTO,
+	WIDGET_SORTBY,
 	WIDGET_KEYPRESS,
 	WIDGET_DROPASK,
 	WIDGET_DROPCOPY,
@@ -54,6 +57,8 @@ char *widget_geticons(Widget *widget);
 WidgetEvent widget_wait(Widget *widget);
 
 int widget_fd(Widget *widget);
+
+const char *widget_get_sortby(Widget *widget);
 
 void widget_map(Widget *widget);
 

--- a/xfiles.1
+++ b/xfiles.1
@@ -532,6 +532,12 @@ or disabled
 (if set to
 .Ic false ) .
 Either option can be used (they are synonyms).
+.It Ic sortBy
+Initial sort order of files (one of
+.Qq Ic "name",
+.Qq Ic "time"
+or
+.Qq Ic "size")
 .El
 .Sh PROPERTIES
 .Nm xfiles
@@ -560,6 +566,14 @@ If this property is set to
 .Nm xfiles
 goes to the next directory in history.
 Otherwise, it goes to the directory whose path is equal to this property's value.
+.It Ic "_CONTROL_SORTBY"
+When this property is modified,
+.Nm xfiles
+sorts the directory contents according to the specified key (one of
+.Qq Ic "name",
+.Qq Ic "time"
+or
+.Qq Ic "size") .
 .El
 .Sh ENVIRONMENT
 The following environment variables affect the execution of


### PR DESCRIPTION
Allows configuring the initial file sort order and changing it later on (eg. via a drop down menu in xfilesctl).

I for once cannot live without sorting by modification time. I need it almost every time I open xfiles.

I am not very happy about the way this is implemented. Especially not how the "sortBy" resource is applied. Basically, it reuses the Widget::sortBy string which is also inelegantly set when receiving the _CONTROL_SORTBY property (analogous to _CONTROL_GOTO). This is then read using a getter (`widget_get_sortby()`) on startup in order to initialize FM::sortBy.

Currently, a single `entrycmp()` function is used. It would also be possible to define one function per sort mode - although once you would like to support ascending/descending, you would have to handle this inside of the callbacks anyway unless you want to double the number of callbacks. So perhaps it's wisest to keep a single `entrycmp()`.

Speaking of ascending/descending: In order to support that, I think, we would need a separate new boolean property and resource. I mean, you could just define name_asc, name_desc, etc. strings to be used with the existing _CONTROL_SORTBY. But, then the property needs to be readable, so that xfilesctl can assemble the correct strings...